### PR TITLE
Fix top padding between status bar and app bar

### DIFF
--- a/app/src/main/java/com/example/upitracker/MainActivity.kt
+++ b/app/src/main/java/com/example/upitracker/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.biometric.BiometricPrompt
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -150,7 +151,8 @@ class MainActivity : FragmentActivity() {
                     }
                 }
                 Scaffold(
-                    snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+                    snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+                    contentWindowInsets = WindowInsets(0)
                 ) { innerPadding ->
                     if (!onboardingCompleted) {
                         OnboardingScreen(

--- a/app/src/main/java/com/example/upitracker/ui/screens/MainAppScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/MainAppScreen.kt
@@ -6,6 +6,7 @@ import android.util.Log // ✨ Add Log import for debugging
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,6 +42,7 @@ fun MainAppScreen(
         modifier = modifier.fillMaxSize(),
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0),
                 title = {
                     val navBackStackEntry by contentNavController.currentBackStackEntryAsState()
                     val currentRoute = navBackStackEntry?.destination?.route

--- a/app/src/main/java/com/example/upitracker/ui/screens/RegexEditorScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/RegexEditorScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.*
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,6 +55,7 @@ fun RegexEditorScreen(
         modifier = modifier,
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets(0),
                 title = { Text(stringResource(R.string.regex_editor_top_bar_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {


### PR DESCRIPTION
## Summary
- remove system bar padding at root `Scaffold`
- disable default status bar insets for app bars to avoid extra spacing

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f7c3364c832ebc41c0ec82a1a6cf