### PR TITLE
Fix top bar insets

### DIFF
--- a/app/src/main/java/com/example/upitracker/MainActivity.kt
+++ b/app/src/main/java/com/example/upitracker/MainActivity.kt
@@ -13,7 +13,6 @@ import androidx.biometric.BiometricPrompt
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -151,8 +150,7 @@ class MainActivity : FragmentActivity() {
                     }
                 }
                 Scaffold(
-                    snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-                    contentWindowInsets = WindowInsets(0)
+                    snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
                 ) { innerPadding ->
                     if (!onboardingCompleted) {
                         OnboardingScreen(

--- a/app/src/main/java/com/example/upitracker/ui/screens/MainAppScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/MainAppScreen.kt
@@ -6,7 +6,7 @@ import android.util.Log // ✨ Add Log import for debugging
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,10 +40,9 @@ fun MainAppScreen(
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
-                windowInsets = WindowInsets(0),
+                windowInsets = TopAppBarDefaults.windowInsets,
                 title = {
                     val navBackStackEntry by contentNavController.currentBackStackEntryAsState()
                     val currentRoute = navBackStackEntry?.destination?.route

--- a/app/src/main/java/com/example/upitracker/ui/screens/RegexEditorScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/RegexEditorScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.*
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,10 +53,9 @@ fun RegexEditorScreen(
 
     Scaffold(
         modifier = modifier,
-        contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
-                windowInsets = WindowInsets(0),
+                windowInsets = TopAppBarDefaults.windowInsets,
                 title = { Text(stringResource(R.string.regex_editor_top_bar_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/app/src/main/java/com/example/upitracker/ui/screens/TabbedHomeScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/TabbedHomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.*
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,9 +81,9 @@ fun TabbedHomeScreen( // This screen might be your "History" tab's content now, 
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
+                windowInsets = TopAppBarDefaults.windowInsets,
                 title = { Text(stringResource(R.string.tabbed_home_top_bar_title)) }, // Or a more specific title if this is for history
                 actions = {
                     IconButton(onClick = { navController.navigate("settings") }) { // Ensure this "settings" route is valid for the passed NavController


### PR DESCRIPTION
## Summary
- revert overriding contentWindowInsets everywhere
- apply `TopAppBarDefaults.windowInsets` so bars respect system insets
- keep decor fitting false in MainActivity

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6843000d04bc832ebf501839ffdad732