### PR TITLE
Fix path length computation for progress draw

### DIFF
--- a/app/src/main/java/com/example/upitracker/ui/screens/GraphsScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/GraphsScreen.kt
@@ -513,13 +513,18 @@ fun SimpleDailyExpenseLineChart(
         val segmentPath = Path()
         if (pointCoordinates.isNotEmpty()) {
             segmentPath.moveTo(pointCoordinates.first().x, pointCoordinates.first().y)
-            val totalLength = pointCoordinates.zipWithNext { a, b -> kotlin.math.hypot((b.x - a.x), (b.y - a.y)) }.sum()
+            val totalLength = pointCoordinates.zipWithNext { a, b ->
+                kotlin.math.hypot((b.x - a.x).toDouble(), (b.y - a.y).toDouble()).toFloat()
+            }.sum()
             var traversed = 0f
             val target = totalLength * drawProgress.value
             for (i in 1 until pointCoordinates.size) {
                 val start = pointCoordinates[i - 1]
                 val end = pointCoordinates[i]
-                val segLength = kotlin.math.hypot((end.x - start.x), (end.y - start.y))
+                val segLength = kotlin.math.hypot(
+                    (end.x - start.x).toDouble(),
+                    (end.y - start.y).toDouble()
+                ).toFloat()
                 if (traversed + segLength <= target) {
                     segmentPath.lineTo(end.x, end.y)
                     traversed += segLength


### PR DESCRIPTION
## Summary
- fix line chart segment calculation for DailyExpenseLineChart

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e10250b0832eabd8e77f4203d786