### PR TITLE
Increase swipe threshold & filter drags

### DIFF
--- a/app/src/main/java/com/example/upitracker/ui/components/TransactionCard.kt
+++ b/app/src/main/java/com/example/upitracker/ui/components/TransactionCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.Delete
@@ -18,6 +19,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.input.pointer.consume
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -72,12 +75,29 @@ fun TransactionCard(
                 SwipeToDismissBoxValue.Settled -> false // Do not dismiss if settled back
             }
         },
-                positionalThreshold = { totalDistance -> totalDistance * 0.50f }
+        positionalThreshold = { totalDistance -> totalDistance * 0.75f }
     )
 
     SwipeToDismissBox( // ✨ Material 3 SwipeToDismissBox ✨
         state = dismissState,
-        modifier = modifier, // Apply fillMaxWidth here
+        modifier = modifier
+            .pointerInput(Unit) {
+                var dragX = 0f
+                var dragY = 0f
+                detectDragGestures(
+                    onDragStart = {
+                        dragX = 0f
+                        dragY = 0f
+                    },
+                    onDrag = { change, amount ->
+                        dragX += amount.x
+                        dragY += amount.y
+                        if (kotlin.math.abs(dragX) > kotlin.math.abs(dragY)) {
+                            change.consume()
+                        }
+                    }
+                )
+            }, // Apply fillMaxWidth here
         enableDismissFromStartToEnd = true, // Swipe Right (Archive)
         enableDismissFromEndToStart = true, // Swipe Left (Delete)
         backgroundContent = {


### PR DESCRIPTION
## Summary
- raise `SwipeToDismissBox` positional threshold so horizontal swipe must pass 75% of width
- add `pointerInput` drag filter so vertical scrolling doesn't trigger the dismiss

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451ec36170832eabee28d2df027f67