### PR TITLE
Add swipe gesture preference toggle

### DIFF
--- a/app/src/main/java/com/example/upitracker/ui/components/TransactionCard.kt
+++ b/app/src/main/java/com/example/upitracker/ui/components/TransactionCard.kt
@@ -39,7 +39,8 @@ fun TransactionCard(
     onClick: (Transaction) -> Unit,
     onLongClick: (Transaction) -> Unit,
     onArchiveSwipeAction: (Transaction) -> Unit,
-    onDeleteSwipeAction: (Transaction) -> Unit
+    onDeleteSwipeAction: (Transaction) -> Unit,
+    swipeActionsEnabled: Boolean = true
 ) {
     val displayDate = remember(transaction.date) {
         try {
@@ -98,8 +99,8 @@ fun TransactionCard(
                     }
                 )
             }, // Apply fillMaxWidth here
-        enableDismissFromStartToEnd = true, // Swipe Right (Archive)
-        enableDismissFromEndToStart = true, // Swipe Left (Delete)
+        enableDismissFromStartToEnd = swipeActionsEnabled, // Swipe Right (Archive)
+        enableDismissFromEndToStart = swipeActionsEnabled, // Swipe Left (Delete)
         backgroundContent = {
             val direction = dismissState.dismissDirection
             val targetValue = dismissState.targetValue // Use targetValue for more stable color during swipe

--- a/app/src/main/java/com/example/upitracker/ui/screens/CurrentMonthExpensesScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/CurrentMonthExpensesScreen.kt
@@ -52,6 +52,8 @@ fun CurrentMonthExpensesScreen(
 
     val currentMonthExpenseItems by mainViewModel.currentMonthExpenseItems.collectAsState()
 
+    val swipeActionsEnabled by mainViewModel.swipeActionsEnabled.collectAsState()
+
     val currencyFormatter = remember { NumberFormat.getCurrencyInstance(Locale("en", "IN")) }
 
     // --- State for Category Edit Dialog ---
@@ -147,7 +149,8 @@ fun CurrentMonthExpensesScreen(
                                     onDeleteSwipeAction = { txnToDeleteFromSwipe -> // ✨ Handle Delete Swipe ✨
                                         // Re-use the confirmation dialog for consistency, or direct delete with undo snackbar
                                         openDeleteConfirmDialog(txnToDeleteFromSwipe)
-                                    }
+                                    },
+                                    swipeActionsEnabled = swipeActionsEnabled
                                 )
                             }
 

--- a/app/src/main/java/com/example/upitracker/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Swipe
 import androidx.activity.compose.rememberLauncherForActivityResult // ✨
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.*
@@ -102,6 +103,21 @@ fun SettingsScreen(
                 Switch(
                     checked = isDarkMode,
                     onCheckedChange = { mainViewModel.toggleDarkMode(it) }
+                )
+            }
+        }
+        item {
+            val swipeEnabled by mainViewModel.swipeActionsEnabled.collectAsState()
+            SettingItemRow(
+                icon = Icons.Filled.Swipe,
+                title = stringResource(R.string.settings_enable_swipe_actions),
+                summary = if (swipeEnabled) stringResource(R.string.settings_swipe_actions_enabled)
+                else stringResource(R.string.settings_swipe_actions_disabled),
+                onClick = { mainViewModel.toggleSwipeActions(!swipeEnabled) }
+            ) {
+                Switch(
+                    checked = swipeEnabled,
+                    onCheckedChange = { mainViewModel.toggleSwipeActions(it) }
                 )
             }
         }

--- a/app/src/main/java/com/example/upitracker/ui/screens/TabbedHomeScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/TabbedHomeScreen.kt
@@ -51,6 +51,7 @@ fun TabbedHomeScreen( // This screen might be your "History" tab's content now, 
     val upiTransactions by mainViewModel.filteredUpiTransactions.collectAsState()
     val liteSummaries by mainViewModel.filteredUpiLiteSummaries.collectAsState() // Assuming you want filtered summaries too
     val isImporting by mainViewModel.isImportingSms.collectAsState()
+    val swipeActionsEnabled by mainViewModel.swipeActionsEnabled.collectAsState()
 
     val pagerState = rememberPagerState { tabTitles.size }
     val coroutineScope = rememberCoroutineScope()
@@ -136,7 +137,8 @@ fun TabbedHomeScreen( // This screen might be your "History" tab's content now, 
                             },
                             onTransactionLongClick = { transaction -> openDeleteConfirmDialog(transaction)},
                             onTransactionArchive = { transaction -> mainViewModel.toggleTransactionArchiveStatus(transaction) },
-                            onTransactionDeleteSwipe = { transaction -> openDeleteConfirmDialog(transaction) }
+                            onTransactionDeleteSwipe = { transaction -> openDeleteConfirmDialog(transaction) },
+                            swipeEnabled = swipeActionsEnabled
                         )
                         1 -> UpiLiteSummaryListContent(
                             summaries = liteSummaries.take(100) // Or full list
@@ -210,7 +212,8 @@ fun UpiTransactionListContent(
     onTransactionClick: (Transaction) -> Unit,
     onTransactionLongClick: (Transaction) -> Unit, // ✨ Added parameter ✨
     onTransactionArchive: (Transaction) -> Unit, // ✨ Added parameter ✨
-    onTransactionDeleteSwipe: (Transaction) -> Unit
+    onTransactionDeleteSwipe: (Transaction) -> Unit,
+    swipeEnabled: Boolean
 ) {
     if (transactions.isEmpty()) {
         EmptyStateView(message = stringResource(R.string.empty_state_no_upi_transactions))
@@ -227,7 +230,8 @@ fun UpiTransactionListContent(
                 onClick = { onTransactionClick(txn) },
                 onLongClick = { onTransactionLongClick(txn) },
                 onArchiveSwipeAction = { onTransactionArchive(txn) },      // ✨ Pass to Card ✨
-                onDeleteSwipeAction = { onTransactionDeleteSwipe(txn) }
+                onDeleteSwipeAction = { onTransactionDeleteSwipe(txn) },
+                swipeActionsEnabled = swipeEnabled
             )
         }
     }

--- a/app/src/main/java/com/example/upitracker/ui/screens/TransactionHistoryScreen.kt
+++ b/app/src/main/java/com/example/upitracker/ui/screens/TransactionHistoryScreen.kt
@@ -66,6 +66,7 @@ fun TransactionHistoryScreen(
     val selectedEndDate by mainViewModel.selectedDateRangeEnd.collectAsState()
     val upiLiteSortField by mainViewModel.upiLiteSummarySortField.collectAsState()
     val upiLiteSortOrder by mainViewModel.upiLiteSummarySortOrder.collectAsState()
+    val swipeActionsEnabled by mainViewModel.swipeActionsEnabled.collectAsState()
 
     // --- DatePickerDialog States (managed within this screen) ---
     var showStartDatePicker by remember { mutableStateOf(false) }
@@ -187,7 +188,8 @@ fun TransactionHistoryScreen(
                                         onDeleteSwipeAction = { txnToDeleteFromSwipe -> // ✨ Handle Delete Swipe ✨
                                             // Re-use the confirmation dialog for consistency, or direct delete with undo snackbar
                                             openDeleteConfirmDialog(txnToDeleteFromSwipe)
-                                        }
+                                        },
+                                        swipeActionsEnabled = swipeActionsEnabled
                                     )
                                 }
                             }

--- a/app/src/main/java/com/example/upitracker/util/ThemePreference.kt
+++ b/app/src/main/java/com/example/upitracker/util/ThemePreference.kt
@@ -16,6 +16,7 @@ val Context.settingsDataStore by preferencesDataStore(name = "app_settings") // 
 
 object ThemePreference {
     private val DARK_MODE_KEY = booleanPreferencesKey("dark_mode_enabled") // Slightly more descriptive key name
+    private val SWIPE_ACTIONS_KEY = booleanPreferencesKey("swipe_actions_enabled")
 
     /**
      * Retrieves the Flow for the dark mode preference.
@@ -32,12 +33,23 @@ object ThemePreference {
                 emit(false)
             }
 
+    fun isSwipeActionsEnabledFlow(context: Context): Flow<Boolean> =
+        context.settingsDataStore.data.map { prefs: Preferences ->
+            prefs[SWIPE_ACTIONS_KEY] ?: true
+        }.catch { emit(true) }
+
     /**
      * Sets the dark mode preference.
      */
     suspend fun setDarkMode(context: Context, enabled: Boolean) {
         context.settingsDataStore.edit { prefs ->
             prefs[DARK_MODE_KEY] = enabled
+        }
+    }
+
+    suspend fun setSwipeActionsEnabled(context: Context, enabled: Boolean) {
+        context.settingsDataStore.edit { prefs ->
+            prefs[SWIPE_ACTIONS_KEY] = enabled
         }
     }
 }

--- a/app/src/main/java/com/example/upitracker/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/example/upitracker/viewmodel/MainViewModel.kt
@@ -117,6 +117,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val isDarkMode: StateFlow<Boolean> = ThemePreference.isDarkModeFlow(application)
         .stateIn(viewModelScope, SharingStarted.Lazily, false)
 
+    val swipeActionsEnabled: StateFlow<Boolean> =
+        ThemePreference.isSwipeActionsEnabledFlow(application)
+            .stateIn(viewModelScope, SharingStarted.Lazily, true)
+
     val isOnboardingCompleted: StateFlow<Boolean> =
         OnboardingPreference.isOnboardingCompletedFlow(application)
             .stateIn(viewModelScope, SharingStarted.Eagerly, false)
@@ -553,6 +557,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun toggleDarkMode(enabled: Boolean) {
         viewModelScope.launch {
             ThemePreference.setDarkMode(getApplication(), enabled)
+        }
+    }
+
+    fun toggleSwipeActions(enabled: Boolean) {
+        viewModelScope.launch {
+            ThemePreference.setSwipeActionsEnabled(getApplication(), enabled)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="settings_dark_mode">Dark Mode</string>
     <string name="settings_dark_mode_enabled">Enabled</string>
     <string name="settings_dark_mode_disabled">Disabled</string>
+    <string name="settings_enable_swipe_actions">Swipe Actions</string>
+    <string name="settings_swipe_actions_enabled">Enabled</string>
+    <string name="settings_swipe_actions_disabled">Disabled</string>
     <string name="table_header_date">Date</string>
     <string name="graph_screen_title">Graphs</string>
     <string name="graph_monthly_expenses_subtitle">Monthly Debit Totals (Last %1$d Months)</string>


### PR DESCRIPTION
## Summary
- allow toggling swipe actions in settings
- store swipeActionsEnabled in DataStore
- respect swipeActionsEnabled in TransactionCard
- pass preference through viewmodel and screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684522bd3bf8832e94384da0c3f72f1f