### PR TITLE
Potential fix for code scanning alert no. 10: Use of implicit PendingIntents

### DIFF
--- a/app/src/main/java/com/example/upitracker/util/NotificationHelper.kt
+++ b/app/src/main/java/com/example/upitracker/util/NotificationHelper.kt
@@ -107,8 +107,10 @@ object NotificationHelper {
             return
         }
 
-        // Create an intent that will open the release URL in a browser
-        val intent = Intent(Intent.ACTION_VIEW, release.htmlUrl.toUri())
+        // Create an explicit intent that opens the release URL in the app's WebViewActivity
+        val intent = Intent(context, WebViewActivity::class.java).apply {
+            putExtra("url", release.htmlUrl)
+        }
         val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
 
         val notificationId = 99 // A fixed ID for the update notification


### PR DESCRIPTION
Potential fix for [https://github.com/Harishhari0525/upitracker/security/code-scanning/10](https://github.com/Harishhari0525/upitracker/security/code-scanning/10)

To resolve the issue, the `Intent` used to create the `PendingIntent` must be made explicit by specifying the destination component (e.g., a specific activity in your app that handles the `Uri`). This ensures that the `Intent` cannot be intercepted by unintended applications. The `PendingIntent` should also retain the `FLAG_IMMUTABLE` flag to prevent further modifications.

Steps to fix:
1. Replace the implicit `Intent` (`Intent.ACTION_VIEW`) with an explicit `Intent` targeting an activity within the app that specifically handles the `release.htmlUrl`.
2. Update the `Intent` creation to include the appropriate component (e.g., the fully qualified class name of the activity).
3. Ensure the rest of the `PendingIntent` remains unchanged to preserve functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
